### PR TITLE
toXML and fromXML methods

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -118,6 +118,38 @@ class VSItem(VSApi):
             raise InvalidData("Did not get created collection ID from Vidispine")
         return self
 
+    def toXML(self,encoding="UTF-8"):
+        """
+        Returns a reconstructed XML document for the metadata of this item.
+        :return: XML string
+        """
+        return ET.tostring(self.dataContent,encoding)
+
+    def fromXML(self, xmlstring=None, type="item"):
+        """
+        populate this item from the given XML document rather than directly from Vidispine
+        :param xmlstring: XML to parse
+        :return: self
+        """
+        self.dataContent = ET.fromstring(xmlstring)
+
+        self.type=type
+        namespace = "{http://xml.vidispine.com/schema/vidispine}"
+        if type == "item":
+            node = self.dataContent.find('{0}item'.format(namespace))
+            self.name = node.attrib['id']
+
+        if type == "item":
+            for x in self.dataContent.findall('{0}item/{0}metadata/{0}timespan'.format(namespace)):
+                self.makeContentDict(x)
+        elif type == "collection":
+            for x in self.dataContent.findall('{0}timespan'.format(namespace)):
+                self.makeContentDict(x)
+            self.name = self.contentDict['collectionId']
+        else:
+            raise TypeError("item populate() called on something not identifying an item or collection")
+        return self
+
     def populate(self, id=None, type="item", specificFields=None):
         """
         Loads metadata about the item from Vidispine.
@@ -134,28 +166,11 @@ class VSItem(VSApi):
 
         if isinstance(specificFields,list) or isinstance(specificFields,tuple):
             fields=",".join(specificFields)
-            self.dataContent = self.request("/{t}/{i}/metadata?field={f}".format(t=type,i=id,f=fields, method="GET"))
+            content = self.request("/{t}/{i}/metadata?field={f}".format(t=type,i=id,f=fields, method="GET"))
         else:
-            self.dataContent = self.request("/%s/%s/metadata" % (type, id), method="GET")
+            content = self.request("/%s/%s/metadata" % (type, id), method="GET")
 
-        # print ET.tostring(self.dataContent)
-        self.type=type
-        #print "Processing..."
-        namespace = "{http://xml.vidispine.com/schema/vidispine}"
-        if type == "item":
-            node = self.dataContent.find('{0}item'.format(namespace))
-            self.name = node.attrib['id']
-
-        if type == "item":
-            for x in self.dataContent.findall('{0}item/{0}metadata/{0}timespan'.format(namespace)):
-                self.makeContentDict(x)
-        elif type == "collection":
-            for x in self.dataContent.findall('{0}timespan'.format(namespace)):
-                self.makeContentDict(x)
-            self.name = self.contentDict['collectionId']
-        else:
-            raise TypeError("item populate() called on something not identifying an item or collection")
-        return self
+        return self.fromXML(content,type)
 
     def importSidecar(self, filepath):
         """

--- a/tests/test_vsitem.py
+++ b/tests/test_vsitem.py
@@ -4,7 +4,10 @@ import unittest2
 from mock import MagicMock, patch
 from urllib2 import quote
 
+
 class TestVSItem(unittest2.TestCase):
+    maxDiff=None
+
     fake_host = 'localhost'
     fake_port = 8080
     fake_user = 'username'
@@ -105,3 +108,76 @@ class TestVSItem(unittest2.TestCase):
             i.import_external_xml(testdoc,projection_name="myprojection")
 
             mock_request.assert_called_once_with("/item/VX-345/metadata", method="PUT", matrix={'projection': 'myprojection'},body=testdoc)
+
+    def test_fromxml(self):
+        testdoc = """<?xml version="1.0" encoding="UTF-8"?>
+        <MetadataListDocument xmlns="http://xml.vidispine.com/schema/vidispine">
+        <item id="VX-1234">
+        <metadata>
+            <timespan start="-INF" end="+INF">
+                <field>
+                    <name>sometestfield</name>
+                    <value>sometestvalue</value>
+                </field>
+                <field>
+                    <name>someotherfield</name>
+                    <value>valueone</value>
+                    <value>valuetwo</value>
+                </field>
+            </timespan>
+            </metadata>
+            </item>
+        </MetadataListDocument>"""
+
+        from gnmvidispine.vs_item import VSItem
+        i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
+        i.fromXML(testdoc)
+
+        self.assertEqual(i.get("sometestfield"),"sometestvalue")
+        self.assertEqual(i.get("someotherfield", allowArray=True),["valueone","valuetwo"])
+
+    def test_toxml(self):
+        testdoc = """<?xml version="1.0" encoding="UTF-8"?>
+        <MetadataListDocument xmlns="http://xml.vidispine.com/schema/vidispine">
+        <item id="VX-1234">
+        <metadata>
+            <timespan start="-INF" end="+INF">
+                <field>
+                    <name>sometestfield</name>
+                    <value>sometestvalue</value>
+                </field>
+                <field>
+                    <name>someotherfield</name>
+                    <value>valueone</value>
+                    <value>valuetwo</value>
+                </field>
+            </timespan>
+            </metadata>
+            </item>
+        </MetadataListDocument>"""
+
+        #christ knows why it gets indented like this, but it does.
+        output_testdoc = """<?xml version='1.0' encoding='UTF-8'?>
+<ns0:MetadataListDocument xmlns:ns0="http://xml.vidispine.com/schema/vidispine">
+        <ns0:item id="VX-1234">
+        <ns0:metadata>
+            <ns0:timespan end="+INF" start="-INF">
+                <ns0:field>
+                    <ns0:name>sometestfield</ns0:name>
+                    <ns0:value>sometestvalue</ns0:value>
+                </ns0:field>
+                <ns0:field>
+                    <ns0:name>someotherfield</ns0:name>
+                    <ns0:value>valueone</ns0:value>
+                    <ns0:value>valuetwo</ns0:value>
+                </ns0:field>
+            </ns0:timespan>
+            </ns0:metadata>
+            </ns0:item>
+        </ns0:MetadataListDocument>"""
+
+        from gnmvidispine.vs_item import VSItem
+        i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
+        i.fromXML(testdoc)
+
+        self.assertEqual(i.toXML(),output_testdoc)

--- a/tests/test_vsitem.py
+++ b/tests/test_vsitem.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import unittest2
 from mock import MagicMock, patch
 from urllib2 import quote
+import xml.etree.cElementTree as ET
+import re
 
 
 class TestVSItem(unittest2.TestCase):
@@ -19,7 +21,26 @@ class TestVSItem(unittest2.TestCase):
     <status>READY</status>
     <type>PLACEHOLDER_IMPORT</type>
 </JobDocument>"""
-    
+
+    testdoc = """<?xml version="1.0" encoding="UTF-8"?>
+    <MetadataListDocument xmlns="http://xml.vidispine.com/schema/vidispine">
+    <item id="VX-1234">
+    <metadata>
+        <timespan start="-INF" end="+INF">
+            <field>
+                <name>sometestfield</name>
+                <value>sometestvalue</value>
+            </field>
+            <field>
+                <name>someotherfield</name>
+                <value>valueone</value>
+                <value>valuetwo</value>
+            </field>
+        </timespan>
+        </metadata>
+        </item>
+    </MetadataListDocument>"""
+
     class MockedResponse(object):
         def __init__(self, status_code, content, reason=""):
             self.status = status_code
@@ -109,75 +130,49 @@ class TestVSItem(unittest2.TestCase):
 
             mock_request.assert_called_once_with("/item/VX-345/metadata", method="PUT", matrix={'projection': 'myprojection'},body=testdoc)
 
-    def test_fromxml(self):
-        testdoc = """<?xml version="1.0" encoding="UTF-8"?>
-        <MetadataListDocument xmlns="http://xml.vidispine.com/schema/vidispine">
-        <item id="VX-1234">
-        <metadata>
-            <timespan start="-INF" end="+INF">
-                <field>
-                    <name>sometestfield</name>
-                    <value>sometestvalue</value>
-                </field>
-                <field>
-                    <name>someotherfield</name>
-                    <value>valueone</value>
-                    <value>valuetwo</value>
-                </field>
-            </timespan>
-            </metadata>
-            </item>
-        </MetadataListDocument>"""
+    def test_populate(self):
+        with patch("gnmvidispine.vs_item.VSItem.request", return_value=ET.fromstring(self.testdoc)) as mock_request:
+            from gnmvidispine.vs_item import VSItem
+            i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
+            i.populate("VX-1234")
 
+            mock_request.assert_called_once_with("/item/VX-1234/metadata",method="GET")
+            self.assertEqual(i.get("sometestfield"),"sometestvalue")
+            self.assertEqual(i.get("someotherfield",allowArray=True),["valueone","valuetwo"])
+
+    def test_fromxml(self):
         from gnmvidispine.vs_item import VSItem
         i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
-        i.fromXML(testdoc)
+        i.fromXML(self.testdoc)
 
         self.assertEqual(i.get("sometestfield"),"sometestvalue")
         self.assertEqual(i.get("someotherfield", allowArray=True),["valueone","valuetwo"])
 
     def test_toxml(self):
-        testdoc = """<?xml version="1.0" encoding="UTF-8"?>
-        <MetadataListDocument xmlns="http://xml.vidispine.com/schema/vidispine">
-        <item id="VX-1234">
-        <metadata>
-            <timespan start="-INF" end="+INF">
-                <field>
-                    <name>sometestfield</name>
-                    <value>sometestvalue</value>
-                </field>
-                <field>
-                    <name>someotherfield</name>
-                    <value>valueone</value>
-                    <value>valuetwo</value>
-                </field>
-            </timespan>
-            </metadata>
-            </item>
-        </MetadataListDocument>"""
+        fix = re.compile(r'((?<=>)(\n[\t]*)(?=[^<\t]))|(?<=[^>\t])(\n[\t]*)(?=<)')
 
         #christ knows why it gets indented like this, but it does.
-        output_testdoc = """<?xml version='1.0' encoding='UTF-8'?>
+        output_testdoc = fix.sub("","""<?xml version='1.0' encoding='UTF-8'?>
 <ns0:MetadataListDocument xmlns:ns0="http://xml.vidispine.com/schema/vidispine">
-        <ns0:item id="VX-1234">
-        <ns0:metadata>
-            <ns0:timespan end="+INF" start="-INF">
-                <ns0:field>
-                    <ns0:name>sometestfield</ns0:name>
-                    <ns0:value>sometestvalue</ns0:value>
-                </ns0:field>
-                <ns0:field>
-                    <ns0:name>someotherfield</ns0:name>
-                    <ns0:value>valueone</ns0:value>
-                    <ns0:value>valuetwo</ns0:value>
-                </ns0:field>
-            </ns0:timespan>
-            </ns0:metadata>
-            </ns0:item>
-        </ns0:MetadataListDocument>"""
+    <ns0:item id="VX-1234">
+    <ns0:metadata>
+        <ns0:timespan end="+INF" start="-INF">
+            <ns0:field>
+                <ns0:name>sometestfield</ns0:name>
+                <ns0:value>sometestvalue</ns0:value>
+            </ns0:field>
+            <ns0:field>
+                <ns0:name>someotherfield</ns0:name>
+                <ns0:value>valueone</ns0:value>
+                <ns0:value>valuetwo</ns0:value>
+            </ns0:field>
+        </ns0:timespan>
+        </ns0:metadata>
+        </ns0:item>
+    </ns0:MetadataListDocument>""")
 
         from gnmvidispine.vs_item import VSItem
         i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
-        i.fromXML(testdoc)
+        i.fromXML(self.testdoc)
 
-        self.assertEqual(i.toXML(),output_testdoc)
+        self.assertEqual(fix.sub("",i.toXML()),output_testdoc)


### PR DESCRIPTION
ability to dump/restore xml versions of items and collections, for caching.

this is necessary to have a representation that can be pushed to memcached or similar, for check_held_media