### PR TITLE
Fix for serializing non-strings and unicode data

### DIFF
--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -261,7 +261,7 @@ class VSApi(object):
         conn = self._conn
 
         if rawData == False and body is not None:
-            body_to_send = body.decode('utf-8',"backslashreplace")
+            body_to_send = body.decode('utf-8',"backslashreplace").encode('utf-8',"backslashreplace")
         else:
             body_to_send = body
 

--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -907,7 +907,7 @@ class VSMetadataBuilder(VSApi):
                 value=[value]
             for v in value:
                 fieldvalue = ET.SubElement(fieldnode,"value")
-                fieldvalue.text = v
+                fieldvalue.text = unicode(v)
 
     def _groupContent(self,parentNode,meta,subgroupmode="add"):
         """

--- a/tests/test_vidispine_api.py
+++ b/tests/test_vidispine_api.py
@@ -382,7 +382,7 @@ class TestVSApi(unittest2.TestCase):
 
         api.sendAuthorized("GET","/path/to/fake/url", dodgy_string,{})
         api._conn.request.assert_called_once_with("GET",
-                                                  u"/path/to/fake/url",
-                                                  u'<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<MetadataDocument xmlns="http://xml.vidispine.com/schema/vidispine"><timespan end="+INF" start="-INF"><field><name>title</name><value>Thousands take to streets in Barcelona to protest against police violence \u2013 video </value></field><field><name>gnm_asset_category</name><value>Master</value></field><field><name>gnm_type</name><value>Master</value></field><fiel',
+                                                  "/path/to/fake/url",
+                                                  '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<MetadataDocument xmlns="http://xml.vidispine.com/schema/vidispine"><timespan end="+INF" start="-INF"><field><name>title</name><value>Thousands take to streets in Barcelona to protest against police violence \xe2\x80\x93 video </value></field><field><name>gnm_asset_category</name><value>Master</value></field><field><name>gnm_type</name><value>Master</value></field><fiel',
                                                   {'Authorization': 'Basic {0}'.format(auth)}
                                                   )

--- a/tests/test_vsitem.py
+++ b/tests/test_vsitem.py
@@ -107,10 +107,10 @@ class TestVSItem(unittest2.TestCase):
 
         i.name = "VX-123"
 
-        testdoc = i._make_metadata_document({"field1": "value1","field2": "value2"})
+        testdoc = i._make_metadata_document({"field1": "value1","field2": "value2","field3": 3})
 
         self.assertEqual(testdoc,"""<?xml version='1.0' encoding='UTF-8'?>
-<MetadataDocument xmlns="http://xml.vidispine.com/schema/vidispine"><timespan end="+INF" start="-INF"><field><name>field2</name><value>value2</value></field><field><name>field1</name><value>value1</value></field></timespan></MetadataDocument>""")
+<MetadataDocument xmlns="http://xml.vidispine.com/schema/vidispine"><timespan end="+INF" start="-INF"><field><name>field2</name><value>value2</value></field><field><name>field3</name><value>3</value></field><field><name>field1</name><value>value1</value></field></timespan></MetadataDocument>""")
 
         testdoc = i._make_metadata_document({"field1": ["value1","value2","value3"], "field2": "value2"})
         self.assertEqual(testdoc,"""<?xml version='1.0' encoding='UTF-8'?>


### PR DESCRIPTION
Certain unicode characters and non-strings in VSItem metadata dictionaries can cause the XML serialization prior to transmit to break.

This fix makes it more robust, ensuring that everything is correctly escaped to truthfully represent the Unicode data with XML escaping and ensuring that every value is converted to a unicode string prior to serialization