### PR TITLE
Full metadata attribute access

### DIFF
--- a/tests/test_vsitem.py
+++ b/tests/test_vsitem.py
@@ -64,7 +64,6 @@ class TestVSItem(unittest2.TestCase):
                           'priority': 'MEDIUM','tag': 'original', 'thumbnails': 'true'},
                          result)
 
-
     def test_import_to_shape(self):
         from gnmvidispine.vs_item import VSItem
         i = VSItem(host=self.fake_host,port=self.fake_port,user=self.fake_user,passwd=self.fake_passwd)
@@ -192,3 +191,35 @@ class TestVSItem(unittest2.TestCase):
         i.fromXML(self.testdoc)
 
         self.assertEqual(fix.sub("",i.toXML()),output_testdoc)
+
+    def test_get_metadata_attributes(self):
+        fake_data = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MetadataDocument xmlns="http://xml.vidispine.com/schema/vidispine">
+    <revision>KP-19029938,KP-19008430,KP-19008428,KP-19008429</revision>
+    <timespan start="-INF" end="+INF">
+        <field uuid="6062c7ee-b4fe-4bbb-b61e-5d3debb05713" user="richard_sprenger" timestamp="2017-06-02T17:46:59.926+01:00" change="KP-19029938">
+            <name>gnm_commission_status</name>
+            <value uuid="d44f4268-f7af-46aa-884f-905855026c74" user="richard_sprenger" timestamp="2017-06-02T17:46:59.926+01:00" change="KP-19029938">Completed</value>
+        </field>
+        <field uuid="9860f876-b9e8-4799-8e68-cb292818a9cd" user="richard_sprenger" timestamp="2017-06-02T11:26:41.478+01:00" change="KP-19008429">
+            <name>gnm_commission_owner</name>
+            <value uuid="19e2cfdd-dd4c-4dc6-b910-6ce55b0c9c93" user="richard_sprenger" timestamp="2017-06-02T11:26:41.478+01:00" change="KP-19008429">11</value>
+            <value uuid="EF41268C-00B4-431D-A36E-6D3B4D59A06A" user="bob_smith" timestamp="2017-06-02T11:26:44.478+01:00" change="KP-19008430">14</value>
+        </field>
+    </timespan>
+</MetadataDocument>"""
+
+        from gnmvidispine.vs_collection import VSCollection
+        i = VSCollection(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
+        i.collectionId="VX-1234"
+        i.fromXML(fake_data, objectClass="collection")
+
+        result = i.get_metadata_attributes("gnm_commission_status")
+        self.assertEqual(result[0].uuid,"6062c7ee-b4fe-4bbb-b61e-5d3debb05713")
+        self.assertEqual(str(result[0].values),'[VSMetadataValue("Completed")]')
+
+        result2 = i.get_metadata_attributes("gnm_commission_owner")
+        self.assertEqual(str(result2[0].values),'[VSMetadataValue("11"), VSMetadataValue("14")]')
+
+        result3 = i.get_metadata_attributes("invalidfieldname")
+        self.assertEqual(result3, None)

--- a/tests/test_vsmetadata.py
+++ b/tests/test_vsmetadata.py
@@ -1,0 +1,62 @@
+# -*- coding: UTF-8 -*-
+from __future__ import absolute_import
+import unittest2
+from mock import MagicMock, patch
+from urllib2 import quote
+import xml.etree.cElementTree as ET
+import re
+from datetime import datetime
+from dateutil.tz import tzoffset
+
+
+class TestVSMetadataValue(unittest2.TestCase):
+    maxDiff=None
+
+    fake_host = 'localhost'
+    fake_port = 8080
+    fake_user = 'username'
+    fake_passwd = 'password'
+
+    def test_loads(self):
+        """
+        VSMetadataValue should load in data from a valid value entry
+        :return:
+        """
+        from gnmvidispine.vs_metadata import VSMetadataValue
+        testdata = ET.fromstring("""<value uuid="19e2cfdd-dd4c-4dc6-b910-6ce55b0c9c93" user="richard_sprenger" timestamp="2017-06-02T11:26:41.478+01:00" change="KP-19008429">11</value>""")
+
+        value = VSMetadataValue(testdata)
+
+        self.assertEqual(value.value,"11")
+        self.assertEqual(value.uuid,"19e2cfdd-dd4c-4dc6-b910-6ce55b0c9c93")
+        self.assertEqual(value.user,"richard_sprenger")
+        self.assertEqual(value.timestamp,datetime(2017, 6, 2, 11, 26, 41, 478000, tzinfo=tzoffset(None, 3600)))
+
+
+class TestVSMetadataAttribute(unittest2.TestCase):
+    maxDiff=None
+
+    fake_host = 'localhost'
+    fake_port = 8080
+    fake_user = 'username'
+    fake_passwd = 'password'
+
+    def test_loads(self):
+        """
+        VSMetadataAttribute should load in data from a valid field entry
+        :return:
+        """
+        from gnmvidispine.vs_metadata import VSMetadataAttribute
+        testdata = ET.fromstring("""<ns0:field xmlns:ns0="http://xml.vidispine.com/schema/vidispine" uuid="9860f876-b9e8-4799-8e68-cb292818a9cd" user="richard_sprenger" timestamp="2017-06-02T11:26:41.478+01:00" change="KP-19008429">
+            <ns0:name>gnm_commission_owner</ns0:name>
+            <ns0:value uuid="19e2cfdd-dd4c-4dc6-b910-6ce55b0c9c93" user="richard_sprenger" timestamp="2017-06-02T11:26:41.478+01:00" change="KP-19008429">11</ns0:value>
+            <ns0:value uuid="EF41268C-00B4-431D-A36E-6D3B4D59A06A" user="bob_smith" timestamp="2017-06-02T11:26:44.478+01:00" change="KP-19008430">14</ns0:value>
+        </ns0:field>""")
+        field = VSMetadataAttribute(testdata)
+
+        self.assertEqual(field.uuid,"9860f876-b9e8-4799-8e68-cb292818a9cd")
+        self.assertEqual(field.user,"richard_sprenger")
+        self.assertEqual(field.change,"KP-19008429")
+        self.assertEqual(field.name,"gnm_commission_owner")
+        #test using repr() that it actually works. assume that VSMetadataValue does its thang based on the unit test for it.
+        self.assertEqual(str(field.values),"[VSMetadataValue(\"11\"), VSMetadataValue(\"14\")]")


### PR DESCRIPTION
adding new objects and VSItem/VSCollection calls to get out full field/value information including UUIDs and changesets