### PR TITLE
DA Add to_cache and from_cache Methods to VSItem

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -908,14 +908,18 @@ class VSItem(VSApi):
         Returns a dictionary of the data in the object
         :return: dictionary of data in the object
         """
-        return self.contentDict
+        from copy import deepcopy
+
+        return deepcopy(self.contentDict)
 
     def from_cache(self, input_dictionary):
         """
         Takes a dictionary and loads it into the object. Returns a VSItem object
         :return: self
         """
-        self.contentDict = input_dictionary
+        from copy import deepcopy
+
+        self.contentDict = deepcopy(input_dictionary)
         return self
 
 

--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -903,6 +903,21 @@ class VSItem(VSApi):
                 cref.name = uri_entry.text
             yield cref
 
+    def to_cache(self):
+        """
+        Returns a dictionary of the data in the object
+        :return: dictionary of data in the object
+        """
+        return self.contentDict
+
+    def from_cache(self, input_dictionary):
+        """
+        Takes a dictionary and loads it into the object. Returns a VSItem object
+        :return: self
+        """
+        self.contentDict = input_dictionary
+        return self
+
 
 class VSMetadataBuilder(VSApi):
     """


### PR DESCRIPTION
Adds two simple methods that allow input and output of object data to and from dictionaries. The from_cache method also returns a populated VSItem object.

Tested on a local virtual machine.

@fredex42 