### PR TITLE
DA Increase Upload Speed

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -812,7 +812,7 @@ class VSItem(VSApi):
         url = "/item/{0}/shape/raw"
         if rename is None: rename=os.path.basename(filename)
         
-        self.chunked_upload_request(io.FileIO(filename),os.path.getsize(filename),chunk_size=1024*1024,
+        self.chunked_upload_request(io.FileIO(filename),os.path.getsize(filename),chunk_size=128*1024*1024,
                                     path=url.format(self.name).format(self.name),filename=rename,
                                     transferPriority=transferPriority,throttle=throttle,query=args,method="POST")
 


### PR DESCRIPTION
Increases the upload speed by one hundred and twenty eight times. I tried two hundred and fifty six times, but that caused things to break.

Allows upload speeds of around one hundred and twenty eight megabytes per second.

Tested on a machine running Mac OS 10.5.8.

@fredex42 

