### PR TITLE
add support for external IDs

### DIFF
--- a/gnmvidispine/vs_external_id.py
+++ b/gnmvidispine/vs_external_id.py
@@ -1,0 +1,88 @@
+from vidispine_api import VSApi
+import xml.etree.cElementTree as ET
+
+
+class ExternalIdNamespace(VSApi):
+    def __init__(self, *args, **kwargs):
+        super(ExternalIdNamespace, self).__init__(*args, **kwargs)
+        self._xmldoc = None
+
+    def populate(self, name):
+        """
+        Loads in information about the given namespace name or raises VSNotFound if not found
+        :param name:
+        :return:
+        """
+        self.name = name
+
+        path = "/external-id/{0}".format(name)
+        self._xmldoc = self.request(path, method="GET")
+        return self
+
+    def create(self, name, regex, priority=0):
+        """
+        Creates a new external ID namespace with the given name and regex, and populates the properties with the result
+        :param name: name for the external ID namespace
+        :param regex: regex against which any given names must match
+        :param priority: priority with which the regex will be applied
+        :return: self, or raises VSException
+        """
+        root = ET.Element("ExternalIdentifierNamespaceListDocument", {'xmlns': self.xmlns.lstrip('{').rstrip('}')})
+        name_el = ET.SubElement(root, "name")
+        name_el.text = name
+        regex_el = ET.SubElement(root, "pattern")
+        regex_el.text = regex
+        prio_el = ET.SubElement(root, "priority")
+        prio_el.text = str(priority)
+
+        path = "/external-id/{0}".format(name)
+        self.name = name
+        self._xmldoc = self.request(path, method="PUT", body=ET.tostring(root, "UTF-8"))
+        return self
+
+    def save(self):
+        """
+        Updates the current state of the server to our state
+        :return: self, or raises VSException
+        """
+        path = "/external-id/{0}".format(self.name)
+        self.request(path,method="PUT",body=ET.tostring(self._xmldoc,encoding="UTF-8"))
+        return self
+
+    def safe_get(self, xpath, default=None):
+        if self._xmldoc is None:
+            raise ValueError("you must populate an ExternalIdNamespace before retrieving data")
+        node = self._xmldoc.find(xpath)
+        if node is not None:
+            return node.text
+        else:
+            return default
+
+    @property
+    def regex(self):
+        return self.safe_get("{0}pattern".format(self.xmlns))
+
+    @regex.setter
+    def regex(self, new_regex):
+        node = self._xmldoc.find("{0}pattern".format(self.xmlns))
+        node.text = new_regex
+
+    @property
+    def pattern(self):
+        return self.regex
+
+    @pattern.setter
+    def pattern(self, new_regex):
+        self.regex = new_regex
+
+    @property
+    def priority(self):
+        return int(self.safe_get("{0}priority".format(self.xmlns), default=0))
+
+    @priority.setter
+    def priority(self, new_prio):
+        if not isinstance(new_prio, int):
+            raise TypeError("New priority must be an integer")
+        node = self._xmldoc.find("{0}priority".format(self.xmlns))
+        node.text = str(new_prio)
+

--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -169,7 +169,7 @@ class VSItem(VSApi):
     def populate(self, entity_id=None, type="item", specificFields=None):
         """
         Loads metadata about the item from Vidispine.
-        :param id: VS ID of the item to load. You only need to specify this if you're loading an item from a specific ID;
+        :param id: VS ID (or external ID) of the item to load. You only need to specify this if you're loading an item from a specific ID;
         if you have got the item from a VSSearch you only need to call populate() if you specified shouldPopulate=False
         in the results() call.  In that case, you can call with no id parameter and it will populate with the ID in item.name
         :param type: either "item" (default) or "collection"
@@ -598,6 +598,24 @@ class VSItem(VSApi):
                 logging.debug("shape tag %s" % shape.tag())
 
             yield shape
+
+    def add_external_id(self, new_id):
+        """
+        Add an external ID to the item. For this to work, new_id  must validate against a known namespace
+        :param new_id:
+        :return:
+        """
+        path = "/item/{0}/external-id/{1}".format(self.name, new_id)
+        self.request(path,method="PUT")
+
+    def remove_external_id(self, old_id):
+        """
+        Remove a given external ID from the item
+        :param old_id: ID to remove
+        :return:
+        """
+        path = "/item/{0}/external-id/{1}".format(self.name, old_id)
+        self.request(path,method="DELETE")
 
     def transcode(self, shapetag, priority='MEDIUM', wait=True, allow_object=False):
         """

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -409,7 +409,7 @@ class VSStorage(VSApi):
             raise
         except ValueError:
             logging.error("storage::fileCount - entry in <hits> was not an integer")
-        raise
+            raise
 
     def files(self, path='/', include_item=True, state=None):
         """

--- a/tests/test_vs_external_id.py
+++ b/tests/test_vs_external_id.py
@@ -1,0 +1,76 @@
+# -*- coding: UTF-8 -*-
+from __future__ import absolute_import
+import unittest2
+from mock import MagicMock, patch, call
+import xml.etree.cElementTree as ET
+
+
+class TestExternalIdNamespace(unittest2.TestCase):
+    sample_doc = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ExternalIdentifierNamespaceDocument xmlns="http://xml.vidispine.com/schema/vidispine">
+    <name>uuid</name>
+    <pattern>[A-Fa-f0-9]{8}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{12}</pattern>
+    <priority>0</priority>
+</ExternalIdentifierNamespaceDocument>"""
+
+    def test_does_populate(self):
+        """
+        ExternalIdNamespace should populate from an XML document provided by the server
+        :return:
+        """
+        with patch("gnmvidispine.vs_external_id.ExternalIdNamespace.request", return_value=ET.fromstring(self.sample_doc)) as mock_request:
+            from gnmvidispine.vs_external_id import ExternalIdNamespace
+            n = ExternalIdNamespace(host="localhost",port=1234,user="me",passwd="secret")
+            n.populate("uuid")
+            self.assertEqual(n.regex, "[A-Fa-f0-9]{8}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{4}\-[A-Fa-f0-9]{12}")
+            self.assertEqual(n.priority, 0)
+            self.assertEqual(n.name, "uuid")
+
+    def test_create(self):
+        """
+        ExternalIdNamespace.create should build an XML document and PUT it to the server
+        :return:
+        """
+        expected_doc = '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<ExternalIdentifierNamespaceListDocument xmlns="http://xml.vidispine.com/schema/vidispine"><name>test</name><pattern>aaaa</pattern><priority>4</priority></ExternalIdentifierNamespaceListDocument>'
+        with patch("gnmvidispine.vs_external_id.ExternalIdNamespace.request", return_value=ET.fromstring(expected_doc)) as mock_request:
+            from gnmvidispine.vs_external_id import ExternalIdNamespace
+            n = ExternalIdNamespace(host="localhost", port=1234, user="me", passwd="secret")
+            n.create("test","aaaa",priority=4)
+
+            mock_request.assert_called_once_with("/external-id/test", method="PUT", body=expected_doc)
+            self.assertEqual(n.regex, "aaaa")
+            self.assertEqual(n.priority, 4)
+            self.assertEqual(n.name, "test")
+
+    def test_setters(self):
+        """
+        attribute setters should update internal DOM representation
+        :return:
+        """
+        with patch("gnmvidispine.vs_external_id.ExternalIdNamespace.request", return_value=ET.fromstring(self.sample_doc)) as mock_request:
+            from gnmvidispine.vs_external_id import ExternalIdNamespace
+            n = ExternalIdNamespace(host="localhost",port=1234,user="me",passwd="secret")
+            n.populate("uuid")
+            n.regex = "updated regex"
+            self.assertEqual(n.regex, "updated regex")
+            n.priority = 12
+            self.assertEqual(n.priority, 12)
+            n.name = "updated name"
+            self.assertEqual(n.name, "updated name")
+
+    def test_save(self):
+        expected_doc = '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n<ns0:ExternalIdentifierNamespaceDocument xmlns:ns0="http://xml.vidispine.com/schema/vidispine">\n    <ns0:name>uuid</ns0:name>\n    <ns0:pattern>aaaa</ns0:pattern>\n    <ns0:priority>4</ns0:priority>\n</ns0:ExternalIdentifierNamespaceDocument>'
+        with patch("gnmvidispine.vs_external_id.ExternalIdNamespace.request", return_value=ET.fromstring(expected_doc)) as mock_request:
+            from gnmvidispine.vs_external_id import ExternalIdNamespace
+            n = ExternalIdNamespace(host="localhost", port=1234, user="me", passwd="secret")
+            n._xmldoc = ET.fromstring(self.sample_doc)
+
+            n.regex = "aaaa"
+            n.priority = 4
+            n.name = "test"
+
+            n.save()
+            mock_request.assert_called_once_with("/external-id/test", method="PUT", body=expected_doc)
+            self.assertEqual(n.regex, "aaaa")
+            self.assertEqual(n.priority, 4)
+            self.assertEqual(n.name, "test")

--- a/tests/test_vsitem.py
+++ b/tests/test_vsitem.py
@@ -224,6 +224,32 @@ class TestVSItem(unittest2.TestCase):
         result3 = i.get_metadata_attributes("invalidfieldname")
         self.assertEqual(result3, None)
 
+    def test_add_external_id(self):
+        """
+        add_external_id should call to VS to set an external ID
+        :return:
+        """
+        with patch('gnmvidispine.vs_item.VSItem.request') as mock_request:
+            from gnmvidispine.vs_item import VSItem
+            i = VSItem(host="localhost",port=1234,user="me",passwd="secret")
+
+            i.name="VX-1234"
+            i.add_external_id("08473AFA-E7D5-4B92-9C4F-81035523A492")
+            mock_request.assert_called_once_with("/item/VX-1234/external-id/08473AFA-E7D5-4B92-9C4F-81035523A492", method="PUT")
+
+    def test_remove_external_id(self):
+        """
+        remove_external_id should call VS to delete external id
+        :return:
+        """
+        with patch('gnmvidispine.vs_item.VSItem.request') as mock_request:
+            from gnmvidispine.vs_item import VSItem
+            i = VSItem(host="localhost",port=1234,user="me",passwd="secret")
+
+            i.name="VX-1234"
+            i.remove_external_id("08473AFA-E7D5-4B92-9C4F-81035523A492")
+            mock_request.assert_called_once_with("/item/VX-1234/external-id/08473AFA-E7D5-4B92-9C4F-81035523A492", method="DELETE")
+
 
 class TestVsMetadataBuilder(unittest2.TestCase):
     maxDiff = None


### PR DESCRIPTION
This adds a new class,  `ExternalIdNamespace`, for managing external ID namespaces, and `add_external_id`/`remove_external_id` methods for a VSItem.

In order for an external ID request to work, the provided ID must match the regex of at least one registered namespace.

It can then be used in place of the VS id when making api calls.