### PR TITLE
If the Delay is More Than 8192 Seconds Reset it to One Second

### DIFF
--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -312,6 +312,9 @@ class VSApi(object):
                 self._delayedcounter+=1
                 self._undelayedcounter=0
 
+                if self._delay > 8192:
+                    self._delay = 1
+
                 logger.warning("Gateway timeout error communicating with {0}. Waiting {1} seconds before trying again.".format(url,self._delay))
                 time.sleep(self._delay)
             else:


### PR DESCRIPTION
Resets the delay to one second if the current value of the delay is more than 8192 seconds (About two and a quarter hours).

@fredex42 