### PR TITLE
Cache Now Loads contentDict and dataContent

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -928,8 +928,8 @@ class VSItem(VSApi):
         """
         from copy import deepcopy
 
-        dictionary_to_return = deepcopy(self.contentDict)
-
+        dictionary_to_return = {}
+        dictionary_to_return['data'] = deepcopy(self.dataContent)
         dictionary_to_return['_vidispine_id'] = deepcopy(self.name)
 
         return dictionary_to_return
@@ -941,8 +941,9 @@ class VSItem(VSApi):
         """
         from copy import deepcopy
 
-        self.contentDict = deepcopy(input_dictionary)
+        self.dataContent = deepcopy(input_dictionary['data'])
         self.name = deepcopy(input_dictionary['_vidispine_id'])
+        self.fromXML(xmldata=self.dataContent)
 
         return self
 


### PR DESCRIPTION
The cache was not loading dataContent. In this change we now store dataContent. When loaded, dataContent is used to populate contentDict with a call to fromXML.

Tested on a local virtual machine.

@fredex42 