### PR TITLE
fromXML Can Now Process ItemDocument XML Data

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -149,11 +149,19 @@ class VSItem(VSApi):
         if self.type == "item":
             node = self.dataContent.find('{0}item'.format(namespace))
             if node is None:
-                raise InvalidSourceError("VSItem::fromXML - declared as item but source document does not have an <item> node")
-            self.name = node.attrib['id']
+                if self.dataContent.tag == '{0}ItemDocument'.format(namespace):
+                    self.name = self.dataContent.attrib['id']
+                    self.type = "itemdocument"
+                else:
+                    raise InvalidSourceError("VSItem::fromXML - declared as item but source document does not have an <item> or <ItemDocument> node")
+            else:
+                self.name = node.attrib['id']
 
         if self.type == "item":
             for x in self.dataContent.findall('{0}item/{0}metadata/{0}timespan'.format(namespace)):
+                self.makeContentDict(x)
+        elif self.type == "itemdocument":
+            for x in self.dataContent.findall('{0}metadata/{0}timespan'.format(namespace)):
                 self.makeContentDict(x)
         elif self.type == "collection":
             for x in self.dataContent.findall('{0}timespan'.format(namespace)):

--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -928,8 +928,8 @@ class VSItem(VSApi):
         """
         from copy import deepcopy
 
-        dictionary_to_return = deepcopy(self.contentDict)
-
+        dictionary_to_return = {}
+        dictionary_to_return['data'] = deepcopy(self.dataContent)
         dictionary_to_return['_vidispine_id'] = deepcopy(self.name)
 
         return dictionary_to_return
@@ -941,8 +941,9 @@ class VSItem(VSApi):
         """
         from copy import deepcopy
 
-        self.contentDict = deepcopy(input_dictionary)
+        self.dataContent = deepcopy(input_dictionary['data'])
         self.name = deepcopy(input_dictionary['_vidispine_id'])
+        self.fromXML(xmldata=self.dataContent)
 
         return self
 

--- a/tests/test_vsitem.py
+++ b/tests/test_vsitem.py
@@ -41,6 +41,23 @@ class TestVSItem(unittest2.TestCase):
         </item>
     </MetadataListDocument>"""
 
+    testdoctwo = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <ItemDocument id="VX-1234" xmlns="http://xml.vidispine.com/schema/vidispine">
+    <metadata>
+        <timespan start="-INF" end="+INF">
+            <field>
+                <name>sometestfield</name>
+                <value>sometestvalue</value>
+            </field>
+            <field>
+                <name>someotherfield</name>
+                <value>valueone</value>
+                <value>valuetwo</value>
+            </field>
+        </timespan>
+        </metadata>
+    </ItemDocument>"""
+
     class MockedResponse(object):
         def __init__(self, status_code, content, reason=""):
             self.status = status_code
@@ -159,6 +176,14 @@ class TestVSItem(unittest2.TestCase):
         from gnmvidispine.vs_item import VSItem
         i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
         i.fromXML(self.testdoc)
+
+        self.assertEqual(i.get("sometestfield"),"sometestvalue")
+        self.assertEqual(i.get("someotherfield", allowArray=True),["valueone","valuetwo"])
+
+    def test_fromxml_can_code_with_ItemDocument(self):
+        from gnmvidispine.vs_item import VSItem
+        i = VSItem(host=self.fake_host, port=self.fake_port, user=self.fake_user, passwd=self.fake_passwd)
+        i.fromXML(self.testdoctwo)
 
         self.assertEqual(i.get("sometestfield"),"sometestvalue")
         self.assertEqual(i.get("someotherfield", allowArray=True),["valueone","valuetwo"])


### PR DESCRIPTION
fromXML has been changed so it can cope with incoming data if it is in an ItemDocument format.

Tested on a local virtual machine and in a unit test.

@fredex42 