### PR TITLE
Fix For Type Error

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -161,6 +161,7 @@ class VSItem(VSApi):
             for x in self.dataContent.findall('{0}item/{0}metadata/{0}timespan'.format(namespace)):
                 self.makeContentDict(x)
         elif self.type == "itemdocument":
+            self.type = "item"
             for x in self.dataContent.findall('{0}metadata/{0}timespan'.format(namespace)):
                 self.makeContentDict(x)
         elif self.type == "collection":


### PR DESCRIPTION
I found an error with the type being set to 'itemdocument' in testing. This fixes that problem, by setting type to 'item' just after we have used it to work out what type of XML processing to do.

Tested on the dev. system.

@fredex42 