### PR TITLE
Fix for Log Statements Under Python 2.7

### DIFF
--- a/gnmvidispine/vs_item.py
+++ b/gnmvidispine/vs_item.py
@@ -243,15 +243,19 @@ class VSItem(VSApi):
                     key = child.find('{0}name'.format(ns)).text
                 except AttributeError:
                     key = ""
-
-                logging.debug("key is {0}".format(key))
-                #try:
+                try:
+                    logging.debug("key is {0}".format(key))
+                except UnicodeEncodeError:
+                    logging.debug(u"key is {0}".format(key))
                 for valNode in child.findall('{0}value'.format(ns)):
                     try:
                         val = valNode.text
                     except AttributeError:
                         val = ""
-                    logging.debug("got {0} for {1}".format(val,key))
+                    try:
+                        logging.debug("got {0} for {1}".format(val, key))
+                    except UnicodeEncodeError:
+                        logging.debug(u"got {0} for {1}".format(val, key))
                     if key in self.contentDict:
                         #raise Exception("contentDict already has a value %s for %s, trying to insert new value %s\n" % (self.contentDict[key],key,val))
                         if isinstance(self.contentDict[key],list):


### PR DESCRIPTION
These log statements can break under Python 2.7. These fixes catch the exceptions and run Python 2.7 compatible log statements.

@fredex42 