### PR TITLE
Logging Fix Under Python 3

### DIFF
--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -51,7 +51,7 @@ class HTTPError(Exception):
             else:
                 return self
         except Exception as e:
-            logging.error(e.message)
+            logging.error(e)
             return self
 
 

--- a/gnmvidispine/vs_job.py
+++ b/gnmvidispine/vs_job.py
@@ -171,7 +171,7 @@ class VSJob(VSApi):
                 timeString=re.sub('\.\d+','',startTimeNode.text)
                 self.contentDict['started'] = datetime.datetime.strptime(timeString,"%Y-%m-%dT%H:%M:%SZ")
             except ValueError as e: #if the date doesn't parse
-                logger.error("ERROR: %s" % e.message)
+                logger.error("ERROR: %s" % e)
                 pass
 
     @property


### PR DESCRIPTION
Under Python 3, exception objects do not have the attribute 'message'. These changes remove the references to 'message'.

Tested on the dev. system.

@fredex42 