### PR TITLE
Fix for Metadata getting Treated as the Wrong Object Type if Input as a Bytes Object

### DIFF
--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -259,8 +259,8 @@ class VSApi(object):
         """
         import time
         attempt = 0
-        str = '%s:%s' % (self.user, self.passwd)
-        auth = base64.encodebytes(str.encode("UTF-8")).decode().replace('\n', '')
+        str_for_user = '%s:%s' % (self.user, self.passwd)
+        auth = base64.encodebytes(str_for_user.encode("UTF-8")).decode().replace('\n', '')
 
         headers['Authorization']="Basic %s" % auth
         if self.run_as is not None:

--- a/gnmvidispine/vs_storage.py
+++ b/gnmvidispine/vs_storage.py
@@ -14,7 +14,7 @@ from time import sleep
 import logging
 import json
 
-from .vidispine_api import HTTPError, VSApi, VSException, VSNotFound
+from .vidispine_api import HTTPError, VSApi, VSException, VSNotFound, always_string
 
 
 class FileAlreadyImportedError(Exception):
@@ -112,6 +112,8 @@ class VSFile(object):
         mdtext = ""
         if isinstance(metadata, str):
             mdtext = metadata
+        if isinstance(metadata, bytes):
+            mdtext = always_string(metadata)
         elif isinstance(metadata, VSMetadata):
             mdtext = metadata.toXML()
 


### PR DESCRIPTION
Under Python 3 the code breaks when a bytes object is input. This fixes it. If a bytes object is found we convert it to a string with the always_string method.

Also takes out use of a built in function name, which I do not think was actually causing a problem, but makes the syntax more correct.

Tested on the dev. system.

@fredex42 