### PR TITLE
Fix for Starting HTTPS Connections Under Python Versions Later than 3.4

### DIFF
--- a/gnmvidispine/vidispine_api.py
+++ b/gnmvidispine/vidispine_api.py
@@ -204,7 +204,7 @@ class VSApi(object):
             self._conn = conn
         else:
             if https:
-                self._conn = http.client.HTTPSConnection(self.host, self.port, strict=False)
+                self._conn = http.client.HTTPSConnection(self.host, self.port)
             else:
                 self._conn = http.client.HTTPConnection(self.host, self.port)
         

--- a/tests/test_vidispine_api.py
+++ b/tests/test_vidispine_api.py
@@ -540,3 +540,11 @@ class TestVSApi(unittest2.TestCase):
         self.assertEqual(always_string_output, '1.1')
         always_string_output = always_string(True)
         self.assertEqual(always_string_output, 'True')
+
+    def test_https(self):
+        """
+        Test if an HTTPS connection can be started
+        :return:
+        """
+        from gnmvidispine.vidispine_api import VSApi
+        api = VSApi(user=self.fake_user, passwd=self.fake_passwd, https=True)


### PR DESCRIPTION
Removes a keyword not present in Python versions later than 3.4 which was causing HTTPS connections to fail.

 Includes a new test to check if HTTPS connections can indeed be started.

Tested in unit tests.

@fredex42 